### PR TITLE
Added change for checking major timezone from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ Africa/Addis_Ababa             Sunday, October 06, 2024 04:49 PM EAT
 
 3. Get major timezones
 
-Currenlty only IST/PST/PDT/UTC
+Currenlty only IST/PST/PDT/UTC by default. But user can set major timezone 
+in their environment with name `MAJOR_TIMEZONES`, this tool pick up those as the major
+versions.
+
+eg. export MAJOR_TIMEZONES=["UTC", "Asia/Kolkata"]
 
 `worldtimebuddy --major`
 

--- a/worldtimebuddy/cli.py
+++ b/worldtimebuddy/cli.py
@@ -2,7 +2,9 @@ import datetime
 import pytz
 import click
 
-MAJOR_TIMEZONES = ['UTC', 'US/Pacific', 'Asia/Kolkata']
+from worldtimebuddy.utils import get_major_tz_from_env
+
+MAJOR_TIMEZONES = get_major_tz_from_env() or ['UTC', 'US/Pacific', 'Asia/Kolkata']
 
 @click.command()
 @click.option('--format', default='%Y-%m-%d %H:%M:%S', help='DateTime format string')

--- a/worldtimebuddy/utils.py
+++ b/worldtimebuddy/utils.py
@@ -1,0 +1,9 @@
+import os
+from typing import List
+
+def get_major_tz_from_env() -> List[str]:
+    try:
+        major_time_zones = os.environ["MAJOR_TIMEZONES"]
+        return list(major_time_zones[1:len(major_time_zones) - 1].split(','))
+    except:
+        return []


### PR DESCRIPTION
Testing:

Without any key for `MAJOR_TIMEZONES`

```
worldtimebuddy --major
UTC                            2024-10-06 17:22:22
PDT                            2024-10-06 10:22:22
Asia/Kolkata                   2024-10-06 22:52:22
```

With the key
```
worldtimebuddy --major
UTC                            2024-10-06 17:22:35
Asia/Kolkata                   2024-10-06 22:52:35
```
